### PR TITLE
setCharacter: use id instead of resourceName

### DIFF
--- a/server/entities/session.ts
+++ b/server/entities/session.ts
@@ -214,7 +214,7 @@ export class Session {
   async setCharacter(characterId: string): Promise<(boolean | Character)> {
     if (this._connection) {
       const characters = await this._connection.getCharacters();
-      const character = characters.find(character => character.getResourceName() === characterId);
+      const character = characters.find(character => character.getId() === characterId);
       if (character) {
         this._characterId = character.getId();
         await this._connection.setCurrentCharacter(character);


### PR DESCRIPTION
The documentation specifies that the character identifier to be used for this route is the id not the resource name, this aligns the character existence check in `setCharacter`.